### PR TITLE
Keep nature of inner sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,25 @@
 {
-  "requires": true,
+  "name": "callbag-flat-map",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "callbag": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/callbag/-/callbag-1.0.3.tgz",
@@ -116,6 +134,261 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callbag-take/-/callbag-take-1.0.0.tgz",
       "integrity": "sha512-qQ220/N6gOJRS4JS/mEVzbsADCaet5QAYZimrvGjjzT87eclQugJOzsae6efaGMf2KejKlPu8LxWZzs+zZ/hBw=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "tape": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
+      "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.3",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.3",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.6.0",
+        "resolve": "1.7.1",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,25 @@
 const test = require('tape');
 const fromPromise = require('callbag-from-promise');
+const fromIter = require('callbag-from-iter');
 const flatMap = require('./index');
+
+function* range(from, to) {
+	let i = from;
+	while (i <= to) yield i++;
+}
+
+const listenableOf = (...values) => (start, sink) => {
+	if (start !== 0) return;
+	let end = false;
+	sink(0, (t, d) => {
+		if (t === 2) end = true;
+	});
+	for (const i of values) {
+		if (end) break;
+		sink(1, i);
+	}
+	sink(2);
+};
 
 test('it creates a new source for every value emitted by input source', t=>{
 	'use strict';
@@ -21,7 +40,6 @@ test('it creates a new source for every value emitted by input source', t=>{
 	};
 	const inputSource = (start, sink) => {
 		if(start !== 0) return;
-		
 		sink(0, (t,d) => {
 			if(t === 2) clearInterval(emitter);
 		});
@@ -55,7 +73,6 @@ test('it should stop emitting when sink unsubscribes', t=>{
 	};
 	const inputSource = (start, sink) => {
 		if(start !== 0) return;
-		
 		sink(0, (t,d) => {
 			if(t === 2) clearInterval(emitter);
 		});
@@ -81,4 +98,171 @@ test('it should stop emitting when sink unsubscribes', t=>{
 		}
 	});
 	setTimeout(() => t.end(), 4000);
+});
+
+test('it should flatten pullable inner sources to a pullable output source', t=>{
+	'use strict';
+	const doSomething = () => fromIter(range(0, 2));
+	const inputSource = fromIter(range(0, 2));
+	const outputSource = flatMap(doSomething, (a, b) => a + '-' + b)(inputSource);
+	const expectedValues = ['0-0', '0-1', '0-2', '1-0', '1-1', '1-2', '2-0', '2-1', '2-2'];
+	const actualValues = [];
+	let talkback;
+	let stopped = false;
+	outputSource(0, (type, d) => {
+		if (type === 0) talkback = d;
+		if (type === 1) actualValues.push(d);
+		if (type === 2) stopped = true;
+	});
+	t.equal(actualValues.length, 0, 'Got no values before first pull');
+	for (let i = 0; i < expectedValues.length; i++) {
+		talkback(1);
+		t.equal(actualValues.length, i + 1, 'Got 1 value on each pull');
+	}
+	t.deepEqual(actualValues, expectedValues, 'Got all values in the right order');
+	t.notOk(stopped, 'Got no end before additional pull');
+	talkback(1);
+	t.ok(stopped, 'Got end on additional pull');
+	t.end();
+});
+
+test('it should flatten pullable inner sources to a pullable output source even if the input source is listenable', t=>{
+	'use strict';
+	const doSomething = () => fromIter(range(0, 2));
+	const inputSource = listenableOf(0, 1, 2);
+	const outputSource = flatMap(doSomething, (a, b) => a + '-' + b)(inputSource);
+
+	const expectedValues = ['0-0', '0-1', '0-2', '1-0', '1-1', '1-2', '2-0', '2-1', '2-2'];
+	const actualValues = [];
+	let talkback;
+	let stopped = false;
+	outputSource(0, (type, d) => {
+		if (type === 0) talkback = d;
+		if (type === 1) actualValues.push(d);
+		if (type === 2) stopped = true;
+	});
+	t.equal(actualValues.length, 0, 'Got no values before first pull');
+	for (let i = 0; i < expectedValues.length; i++) {
+		talkback(1);
+		t.equal(actualValues.length, i + 1, 'Got 1 value on each pull');
+	}
+	t.deepEqual(actualValues, expectedValues, 'Got all values in the right order');
+	t.notOk(stopped, 'Got no end before additional pull');
+	talkback(1);
+	t.ok(stopped, 'Got end on additional pull');
+	t.end();
+});
+
+test('it should immediately send upstream messages to the oldest inner source without waiting for a push response to the previous message', t=>{
+	t.plan(3);
+	const doSomething = value => (start, sink) => {
+		if (start !== 0) return;
+		let buffer = [];
+		sink(0, (t, d) => {
+			if (t === 1) {
+				if (d !== value) buffer.push(d);
+				else {
+					buffer.forEach(x => sink(1, x));
+					sink(2);
+				}
+			}
+			if (t === 2) sink(2);
+		});
+	};
+	const inputSource = listenableOf(0, 3, 6);
+	const outputSource = flatMap(doSomething, (a, b) => a + '-' + b)(inputSource);
+
+	const expectedValues = ['3-0', '3-1', '3-2', '6-3', '6-4', '6-5'];
+	const actualValues = [];
+	let talkback;
+	outputSource(0, (type, d) => {
+		if (type === 0) talkback = d;
+		if (type === 1) actualValues.push(d);
+		if (type === 2) {
+			t.equal(actualValues.length, expectedValues.length, 'Got only the right values');
+			t.deepEqual(actualValues, expectedValues, 'Got all values in the right order');
+			t.end();
+		};
+	});
+	t.equal(actualValues.length, 0, 'Got no values before first pull');
+	for (let i = 0; i <= expectedValues.length; i++) talkback(1, i);
+});
+
+test('it should re-send upstream messages to the next inner source when the previous one stopped without pushing back a value', t=>{
+	t.plan(3);
+	const doSomething = value => (start, sink) => {
+		if (start !== 0) return;
+		let ids = [];
+		let endId;
+		sink(0, (t, d) => {
+			if (t === 1) {
+				if (endId) return;
+				if (d === value) endId = setTimeout(() => sink(2));
+				else ids.push(setTimeout(() => {
+					ids.shift();
+					sink(1, d);
+				}));
+			}
+			if (t === 2) {
+				ids.forEach(clearTimeout);
+				clearTimeout(endId);
+				sink(2);
+			}
+		});
+	};
+	const inputSource = listenableOf(0, 3, 6);
+	const outputSource = flatMap(doSomething, (a, b) => a + '-' + b)(inputSource);
+
+	const expectedValues = ['3-0', '3-1', '3-2', '6-3', '6-4', '6-5'];
+	const actualValues = [];
+	let talkback;
+	let timeout;
+	outputSource(0, (type, d) => {
+		if (type === 0) talkback = d;
+		if (type === 1) actualValues.push(d);
+		if (type === 2) {
+			t.equal(actualValues.length, expectedValues.length, 'Got only the right values');
+			t.deepEqual(actualValues, expectedValues, 'Got all values in the right order');
+			t.end();
+			clearTimeout(timeout);
+		};
+	});
+	setTimeout(() => {
+		t.equal(actualValues.length, 0, 'Got no values before first pull');
+		for (let i = 0; i <= expectedValues.length; i++) talkback(1, i);
+		timeout = setTimeout(() => t.end(), 2000);
+	});
+});
+
+test('it should not overflow the stack when delivering a message to many empty pullable inner sources', t=>{
+	const doSomething = () => (start, sink) => {
+		if (start !== 0) return;
+		sink(0, (t, d) => {
+			if (t === 1 || t === 0) sink(2);
+		});
+	};
+	const inputSource = (start, sink) => {
+		if (start !== 0) return;
+		let end = false;
+		sink(0, (t, d) => {
+			if (t === 2) end = true;
+		});
+		for (let i = 0; i < 10000; i++) {
+			if (end) break;
+			sink(1, i);
+		}
+		sink(2);
+	};
+	const outputSource = flatMap(doSomething)(inputSource);
+	let stopped = false;
+	let talkback;
+	outputSource(0, (type, d) => {
+		t.notEqual(type, 1, 'Never got any value');
+		if (type === 0) talkback = d;
+		if (type === 2) stopped = true;
+	});
+	t.notOk(stopped, 'Got no end before first pull');
+	t.doesNotThrow(() => talkback(1), null, 'No error thrown on pull');
+	t.ok(stopped, 'Got end on first pull');
+	t.end();
 });


### PR DESCRIPTION
Fixes #4.

Now pullable inner sources are now flattened to a pullable output source.
Works with synchronous, asynchronous, and hybrid sources.

The only assumtions are:
* inner sources are homogeneous, i.e. not mixed listenable and pullable.
* every message sent from the sink to the output source is a pull of the next item, and therefore be delivered to the first inner source until a value is pushed back.

The basic idea is:
* Messages from the sink are added to a queue.
* An index points to the next message to be sent to an inner source. Initially it is 0.
* The oldest inner source is the current source. All messages are sent to the current source.
* When the current source pushes data, the first message in the queue is considered delivered and therefore removed.
* When the current source terminates, the index is reset to 0 and the oldes of the remaining inner sources becomes the current source.
* Start over from sending all messages to the new current source.
