### PR TITLE
fix confusing spelling in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # callbag-flat-map 👜
 
-A callbag operator that creates and flates to the new source whenever original source emits
+A callbag operator that creates and flattens to the new source whenever original source emits
 
 `npm install callbag-flat-map`
 


### PR DESCRIPTION
I'm guessing this is supposed to say 'flatten' in the README?

I think the description is still confusing. 